### PR TITLE
Added debug logging for ASR matches

### DIFF
--- a/lib/adhearsion-asr/controller_methods.rb
+++ b/lib/adhearsion-asr/controller_methods.rb
@@ -90,6 +90,7 @@ module AdhearsionASR
           raise ListenError, reason.details
         when Punchblock::Event::Complete::Reason
           result.status = reason.name
+          logger.debug "Listen has completed with status '#{result.status}'"
         else
           raise "Unknown completion reason received: #{reason}"
         end


### PR DESCRIPTION
This is meant to allow match information to be displayed in debug logging mode, as per request by @bklang
