### PR TITLE
Don’t override server-supplied timeouts

### DIFF
--- a/lib/adhearsion-asr/prompt_builder.rb
+++ b/lib/adhearsion-asr/prompt_builder.rb
@@ -6,8 +6,6 @@ module AdhearsionASR
       input_options = {
         mode: options[:mode] || :dtmf,
         initial_timeout: (options[:timeout] || Plugin.config.timeout) * 1000,
-        inter_digit_timeout: (options[:timeout] || Plugin.config.timeout) * 1000,
-        max_silence: (options[:timeout] || Plugin.config.timeout) * 1000,
         min_confidence: Plugin.config.min_confidence,
         grammars: grammars,
         recognizer: Plugin.config.recognizer,

--- a/spec/adhearsion-asr/controller_methods_spec.rb
+++ b/spec/adhearsion-asr/controller_methods_spec.rb
@@ -61,8 +61,6 @@ module AdhearsionASR
         {
           mode: :dtmf,
           initial_timeout: 5000,
-          inter_digit_timeout: 5000,
-          max_silence: 5000,
           min_confidence: 0.5,
           recognizer: nil,
           language: 'en-US',
@@ -305,9 +303,7 @@ module AdhearsionASR
           let(:expected_grxml) { digit_limit_grammar }
 
           before do
-            expected_input_options.merge! initial_timeout: 10000,
-              inter_digit_timeout: 10000,
-              max_silence: 10000
+            expected_input_options.merge! initial_timeout: 10000
           end
 
           it "executes a Prompt with correct timeout (initial, inter-digit & max-silence)" do
@@ -321,9 +317,7 @@ module AdhearsionASR
           let(:expected_grxml) { digit_limit_grammar }
 
           before do
-            expected_input_options.merge! initial_timeout: 10000,
-              inter_digit_timeout: 10000,
-              max_silence: 10000
+            expected_input_options.merge! initial_timeout: 10000
           end
 
           temp_config_value :timeout, 10
@@ -708,9 +702,7 @@ module AdhearsionASR
 
           context "with a timeout specified" do
             before do
-              expected_input_options.merge! initial_timeout: 10000,
-                inter_digit_timeout: 10000,
-                max_silence: 10000
+              expected_input_options.merge! initial_timeout: 10000
             end
 
             it "executes a Prompt with correct timeout (initial, inter-digit & max-silence)" do
@@ -724,9 +716,7 @@ module AdhearsionASR
 
           context "with a different default timeout" do
             before do
-              expected_input_options.merge! initial_timeout: 10000,
-                inter_digit_timeout: 10000,
-                max_silence: 10000
+              expected_input_options.merge! initial_timeout: 10000
             end
 
             temp_config_value :timeout, 10


### PR DESCRIPTION
The current implementation of PromptBuilder makes a somewhat naive assumption that the provided `timeout` setting should apply to three different kinds of time-outs.  The intent seems to apply best to the `initial-timeout`, or the amount of time the input should wait for the user to start signaling a response. But it’s also default-applied to `max-silence` and `inter-digit` timeouts. This is bad for callers who may take up to 4 seconds to start talking, and then have to wait up to 4 additional seconds after they stop talking for an answer. The server-supplied timeouts (LumenVox is around 800ms) should be the default, while still being possible to override them by the caller to `#ask`.
