### PR TITLE
[FEATURE] Disable timeouts with -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/adhearsion-asr)
   * Bugfix: Correctly handle nil prompts
+  * Feature: Allow disabling timeouts with -1
 
 # [v1.2.0](https://github.com/adhearsion/adhearsion-asr/compare/1.1.1...1.2.0) - [2014-03-03](https://rubygems.org/gems/adhearsion-asr/versions/1.2.0)
   * Feature: Allow setting `:mode` option to `:voice` for ASR menus

--- a/lib/adhearsion-asr/prompt_builder.rb
+++ b/lib/adhearsion-asr/prompt_builder.rb
@@ -5,9 +5,9 @@ module AdhearsionASR
     def initialize(output_document, grammars, options)
       input_options = {
         mode: options[:mode] || :dtmf,
-        initial_timeout: (options[:timeout] || Plugin.config.timeout) * 1000,
-        inter_digit_timeout: (options[:timeout] || Plugin.config.timeout) * 1000,
-        max_silence: (options[:timeout] || Plugin.config.timeout) * 1000,
+        initial_timeout: timeout(options[:timeout] || Plugin.config.timeout),
+        inter_digit_timeout: timeout(options[:timeout] || Plugin.config.timeout),
+        max_silence: timeout(options[:timeout] || Plugin.config.timeout),
         min_confidence: Plugin.config.min_confidence,
         grammars: grammars,
         recognizer: Plugin.config.recognizer,
@@ -63,6 +63,10 @@ module AdhearsionASR
         end
         logger.debug "Ask completed with result #{result.inspect}"
       end
+    end
+
+    def timeout(value)
+      value > 0 ? value * 1000 : value
     end
   end
 end

--- a/spec/adhearsion-asr/controller_methods_spec.rb
+++ b/spec/adhearsion-asr/controller_methods_spec.rb
@@ -317,6 +317,22 @@ module AdhearsionASR
           end
         end
 
+        context "with a negative timeout specified" do
+          let(:expected_grxml) { digit_limit_grammar }
+
+          before do
+            expected_input_options.merge! initial_timeout: -1,
+              inter_digit_timeout: -1,
+              max_silence: -1
+          end
+
+          it "executes a Prompt with correct timeout (initial, inter-digit & max-silence)" do
+            expect_component_execution expected_prompt
+
+            subject.ask prompts, limit: 5, timeout: -1
+          end
+        end
+
         context "with a different default timeout" do
           let(:expected_grxml) { digit_limit_grammar }
 


### PR DESCRIPTION
At the moment, passing `-1` as timeout to `#ask` results in `initial-timeout=-1000`. We could go with `false` as well.
